### PR TITLE
Fix reloading of additional_permitted_attributes

### DIFF
--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -74,7 +74,7 @@ module OpenProject::Plugins
       # Example:
       #  additional_permitted_attributes :user => [:registration_reason]
       base.send(:define_method, :additional_permitted_attributes) do |attributes|
-        base.initializer "#{engine_name}.add_permitted_attributes" do |app|
+        config.to_prepare do
           ::PermittedParams.send(:add_permitted_attributes, attributes)
         end
       end


### PR DESCRIPTION
The additional_permitted_attributes method, which is generated by this
plugin, only worked in production or the first development-request.

Now we insert the additional permitted attributes on every code reload.

This bug was found during: https://www.openproject.org/work_packages/7255
